### PR TITLE
Fix the URL template for downloading the solr-typo3-plugin JAR file

### DIFF
--- a/modules/typo3/main.tf
+++ b/modules/typo3/main.tf
@@ -57,6 +57,6 @@ resource "mittwald_remote_file" "typo3_solr_plugin" {
   stack_id = var.solr_stack_id
   container_id = var.solr_container_id
 
-  contents_from_url = "https://github.com/TYPO3-Solr/ext-solr/raw/refs/${local.ref}/Resources/Private/Solr/typo3lib/solr-typo3-plugin-${local.plugin_version}.jar"
+  contents_from_url = "https://github.com/TYPO3-Solr/ext-solr/raw/${local.ref}/Resources/Private/Solr/typo3lib/solr-typo3-plugin-${local.plugin_version}.jar"
   path = "/var/solr/data/${var.solr_core_name}/lib/solr-typo3-plugin-${local.plugin_version}.jar"
 }


### PR DESCRIPTION
`mittwald_remote_file "typo3_solr_plugin"` specifies `refs/` twice in the URL used with `contents_from_url`. The ref has already been prepended with the string `refs/` in the ref local variable. Thus, it must not be added in the URL pattern again.